### PR TITLE
separate logger file allows us to preserve actual file line numbers

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -40,6 +40,7 @@
     <script src="cordova.js"></script>   <!-- cordova script (this will be a 404 during development) -->
 
       <!-- your app's js -->
+    <script src="js/qmLogger.js"></script>
     <script src="js/qmHelpers.js"></script>
     <script src="js/app.js"></script>
 

--- a/www/js/qmHelpers.js
+++ b/www/js/qmHelpers.js
@@ -34,66 +34,7 @@ var appConfigFileNames = {
     "your_quantimodo_client_id_here": "your_quantimodo_client_id_here"
 };
 window.isTruthy = function(value){return value && value !== "false"; };
-window.getDebugMode = function() {
-    //return true;
-    if(window.getUrlParameter('debug') || window.getUrlParameter('debugMode') || (typeof appSettings !== "undefined" && window.isTruthy(appSettings.debugMode))){
-        window.debugMode = true;
-    }
-    return window.debugMode;
-};
-function getStackTrace() {
-    var err = new Error();
-    var stackTrace = err.stack;
-    stackTrace = stackTrace.substring(stackTrace.indexOf('getStackTrace')).replace('getStackTrace', '');
-    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logDebug')).replace('window.logDebug', '');
-    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logInfo')).replace('window.logInfo', '');
-    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logError')).replace('window.logError', '');
-    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logDebug')).replace('window.logDebug', '');
-    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logInfo')).replace('window.logInfo', '');
-    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logError')).replace('window.logError', '');
-    return stackTrace;
-}
-function addStackTraceToMessage(message, stackTrace) {
-    if(message.toLowerCase().indexOf('stacktrace') !== -1){return message;}
-    if(!stackTrace){stackTrace = getStackTrace();}
-    return message + ".  StackTrace: " + stackTrace;
-}
-function addCallerFunctionToMessage(message) {
-    var calleeFunction = arguments.callee.caller.caller;
-    if(calleeFunction && calleeFunction.name && calleeFunction.name !== ""){
-        message = "callee " + calleeFunction.name + ": " + message;
-    } else if (window.getDebugMode()) {
-        return addStackTraceToMessage(message);
-    }
-    var callerFunction;
-    if(calleeFunction){
-        try {
-            callerFunction = calleeFunction.caller;
-        } catch (error) {
-            console.error(error);
-        }
-    }
-    if(callerFunction && callerFunction.name && callerFunction.name !== ""){
-        return "Caller " + callerFunction.name + " called " + message;
-    } else if (window.getDebugMode()) {
-        return addStackTraceToMessage(message);
-    }
-    return message;
-}
-window.logDebug = function(message) {
-    message = addCallerFunctionToMessage(message);
-    if(window.getDebugMode()){console.debug(message);}
-};
-window.logInfo = function(message) {
-    message = addCallerFunctionToMessage(message);
-    console.info(message);
-};
-window.logError = function(message, additionalMetaData, stackTrace) {
-    if(message && message.message){message = message.message;}
-    message = addCallerFunctionToMessage(message);
-    bugsnagNotify(message, additionalMetaData, stackTrace);
-    console.error(message);
-};
+window.isFalsey = function(value) {if(value === false || value === "false"){return true;}};
 function getSubDomain(){
     var full = window.location.host;
     var parts = full.split('.');
@@ -764,7 +705,6 @@ window.showPopupForMostRecentNotification = function(){
         window.logInfo("No notifications for popup");
     }
 };
-window.isFalsey = function(value) {if(value === false || value === "false"){return true;}};
 function getRatingNotificationPath(trackingReminderNotification){
     return "android_popup.html?variableName=" + trackingReminderNotification.variableName +
     "&valence=" + trackingReminderNotification.valence +

--- a/www/js/qmLogger.js
+++ b/www/js/qmLogger.js
@@ -1,0 +1,62 @@
+// A separate logger file allows us to use "black-boxing" in the Chrome dev console to preserve actual file line numbers
+window.isTruthy = function(value){return value && value !== "false"; };
+window.getDebugMode = function() {
+    //return true;
+    if(window.getUrlParameter('debug') || window.getUrlParameter('debugMode') || (typeof appSettings !== "undefined" && window.isTruthy(appSettings.debugMode))){
+        window.debugMode = true;
+    }
+    return window.debugMode;
+};
+function getStackTrace() {
+    var err = new Error();
+    var stackTrace = err.stack;
+    stackTrace = stackTrace.substring(stackTrace.indexOf('getStackTrace')).replace('getStackTrace', '');
+    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logDebug')).replace('window.logDebug', '');
+    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logInfo')).replace('window.logInfo', '');
+    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logError')).replace('window.logError', '');
+    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logDebug')).replace('window.logDebug', '');
+    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logInfo')).replace('window.logInfo', '');
+    stackTrace = stackTrace.substring(stackTrace.indexOf('window.logError')).replace('window.logError', '');
+    return stackTrace;
+}
+function addStackTraceToMessage(message, stackTrace) {
+    if(message.toLowerCase().indexOf('stacktrace') !== -1){return message;}
+    if(!stackTrace){stackTrace = getStackTrace();}
+    return message + ".  StackTrace: " + stackTrace;
+}
+function addCallerFunctionToMessage(message) {
+    var calleeFunction = arguments.callee.caller.caller;
+    if(calleeFunction && calleeFunction.name && calleeFunction.name !== ""){
+        message = "callee " + calleeFunction.name + ": " + message;
+    } else if (window.getDebugMode()) {
+        return addStackTraceToMessage(message);
+    }
+    var callerFunction;
+    if(calleeFunction){
+        try {
+            callerFunction = calleeFunction.caller;
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    if(callerFunction && callerFunction.name && callerFunction.name !== ""){
+        return "Caller " + callerFunction.name + " called " + message;
+    } else if (window.getDebugMode()) {
+        return addStackTraceToMessage(message);
+    }
+    return message;
+}
+window.logDebug = function(message) {
+    message = addCallerFunctionToMessage(message);
+    if(window.getDebugMode()){console.debug(message);}
+};
+window.logInfo = function(message) {
+    message = addCallerFunctionToMessage(message);
+    console.info(message);
+};
+window.logError = function(message, additionalMetaData, stackTrace) {
+    if(message && message.message){message = message.message;}
+    message = addCallerFunctionToMessage(message);
+    bugsnagNotify(message, additionalMetaData, stackTrace);
+    console.error(message);
+};


### PR DESCRIPTION
A separate logger file allows us to use "black-boxing" in the Chrome dev console to preserve actual file line numbers